### PR TITLE
Fix umbrella header not found

### DIFF
--- a/waifu2x-ios.xcodeproj/project.pbxproj
+++ b/waifu2x-ios.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		8AC63BCE2018325A001498E0 /* UIImage+Alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63BBE20183259001498E0 /* UIImage+Alpha.swift */; };
 		8AC63BCF2018325A001498E0 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63BBF2018325A001498E0 /* BackgroundTask.swift */; };
 		8AC63BD02018325A001498E0 /* UIImage+Expand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63BC02018325A001498E0 /* UIImage+Expand.swift */; };
-		8AC63BD12018325A001498E0 /* waifu2x.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AC63BC12018325A001498E0 /* waifu2x.h */; };
+		8AC63BD12018325A001498E0 /* waifu2x.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AC63BC12018325A001498E0 /* waifu2x.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AC63BD22018325A001498E0 /* UIImage+Bicubic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63BC22018325A001498E0 /* UIImage+Bicubic.swift */; };
 		8AC63BE8201832AD001498E0 /* up_anime_scale2x_model.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63BD5201832A9001498E0 /* up_anime_scale2x_model.mlmodel */; };
 		8AC63BE9201832AD001498E0 /* photo_noise3_model.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63BD6201832A9001498E0 /* photo_noise3_model.mlmodel */; };


### PR DESCRIPTION
Fix umbrella header not found error.
<img width="264" alt="截圖 2020-04-27 15 07 30" src="https://user-images.githubusercontent.com/1047661/80339444-9d616100-8899-11ea-9172-d02ae51cd64f.png">

Move waifu2x.h from project to public
[stackoverflow](https://stackoverflow.com/questions/30355133/swift-framework-umbrella-header-h-not-found)
<img width="743" alt="截圖 2020-04-27 15 08 14" src="https://user-images.githubusercontent.com/1047661/80339451-a0f4e800-8899-11ea-98c6-031d43962a0e.png">
